### PR TITLE
Fix copy-pasta error in Readme.md chiclet

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Status
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Build Status](https://travis-ci.org/unixorn/containerized-awscli.svg?branch=master)](https://travis-ci.org/unixorn/awesome-zsh-plugins)
+[![Build Status](https://travis-ci.org/unixorn/containerized-awscli.svg?branch=master)](https://travis-ci.org/unixorn/containerized-awscli)
 [![GitHub stars](https://img.shields.io/github/stars/unixorn/containerized-awscli.svg)](https://github.com/unixorn/containerized-awscli/stargazers)
 [![Code Climate](https://codeclimate.com/github/unixorn/containerized-awscli/badges/gpa.svg)](https://codeclimate.com/github/unixorn/containerized-awscli)
 [![Issue Count](https://codeclimate.com/github/unixorn/containerized-awscli/badges/issue_count.svg)](https://codeclimate.com/github/unixorn/containerized-awscli)


### PR DESCRIPTION
# Description

I had copy-pasted the chiclets from another one of my repos and missed
updating one of the links.

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] Script additions
- [x] Text cleanups/typo fixes
- [ ] Test updates

# Quality checks

- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` and `#!/bin/bash` are acceptable exceptions)
- [ ] Scripts added/updated in this PR are marked executable

# Copyright Assignment

- [x] This document is covered by the [Apache 2.0](https://github.com/unixorn/containierized-awscli/blob/master/LICENSE) license, and I agree to contribute this PR under the terms of the license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new and existing tests passed.
