### PR TITLE
Switch to building on top of debian:stretch-slim from alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM unixorn/alpython3
-
+FROM debian:stretch-slim
 LABEL maintainer="Joe Block <jpb@unixorn.net>"
-LABEL description="aws cli tools in Alpine 3.7"
+LABEL description="aws cli tools on debian stretch-slim"
 
-RUN apk add --no-cache bash
+RUN apt-get update && apt-get upgrade -y --no-install-recommends && apt-get install -y --no-install-recommends python3-pip
 
 # Install AWS tools
-RUN pip install awscli s3cmd
+RUN pip3 install setuptools wheel && pip3 install awscli s3cmd
 
 # Set up entrypoint
 COPY entrypoint /usr/local/bin/entrypoint

--- a/bin/build-containerized-awscli-if-required
+++ b/bin/build-containerized-awscli-if-required
@@ -32,6 +32,8 @@ build-containerized-awscli-if-required() {
     OLD_DOCKERFILE_HASH=$(cat "${HASH_F}")
     if [[ "${DOCKERFILE_HASH}" == "${OLD_DOCKERFILE_HASH}" ]]; then
       BUILD='NO'
+    else
+      BUILD='YES'
     fi
   fi
 
@@ -43,6 +45,8 @@ build-containerized-awscli-if-required() {
       debugOut "build ok, writing hash to $HASH_F"
       echo $DOCKERFILE_HASH > "${HASH_F}"
     fi
+  else
+    debugOut "Dockerfile unchanged, skipping rebuild"
   fi
 }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- If you're unsure about anything in this checklist, don't hesitate to create a PR and ask. I'm happy to help! -->

# Description

* Debian gets more timely security updates than Alpine does
* Fix bug in rebuild logic - we weren't checking the md5 sum of the Dockerfile if we'd already built the container once

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [ ] Script additions
- [ ] Text cleanups/typo fixes
- [ ] Test updates

# Quality checks

- [ ] Any scripts added use `#!/usr/bin/env interpreter` instead of direct paths (`#!/bin/sh` and `#!/bin/bash` are acceptable exceptions)
- [ ] Scripts added/updated in this PR are marked executable

# Copyright Assignment

- [x] This document is covered by the [Apache 2.0](https://github.com/unixorn/containierized-awscli/blob/master/LICENSE) license, and I agree to contribute this PR under the terms of the license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new and existing tests passed.
