### PR TITLE
Optimize multiarch builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,9 @@
-FROM debian:buster-slim
+FROM unixorn/debian-py3
 LABEL maintainer="Joe Block <jpb@unixorn.net>"
 LABEL description="aws cli tools on debian buster-slim"
 
-RUN apt-get update && \
-    apt-get install -y apt-utils && \
-    apt-get upgrade -y --no-install-recommends && \
-    apt-get install -y --no-install-recommends python3-pip && \
-		rm -fr /tmp/* /var/lib/apt/lists/*
-
 # Install AWS tools
-RUN pip3 install setuptools wheel && \
-    pip3 install awscli s3cmd
+RUN pip3 install awscli s3cmd
 
 # Set up entrypoint
 COPY entrypoint /usr/local/bin/entrypoint

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
 task :default => [:usage]
 task :help => [:usage]
 task :clean => [:purge]
-task :build => [:build_container]
-task :b => [:build_container]
+task :build => [:multiarch_build]
+task :b => [:multiarch_build]
 
 CONTAINER_NAME = 'unixorn/containerized-awscli'
 PROCESSOR=`uname -m`.strip()


### PR DESCRIPTION
# Description

* Make Dockerfile depend on unixorn/debian-py3
* Update Rakefile shortcuts to use multiarch targets

# Type of changes

# Copyright Assignment

- [x] This document is covered by the [Apache 2.0](https://github.com/unixorn/containierized-awscli/blob/master/LICENSE) license, and I agree to contribute this PR under the terms of the license.

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new and existing tests passed.
